### PR TITLE
Add courses app Models to Administration Site

### DIFF
--- a/courses/admin.py
+++ b/courses/admin.py
@@ -1,3 +1,20 @@
 from django.contrib import admin
+from .models import Subject, Course, Module
 
 # Register your models here.
+@admin.register(Subject)
+class SubjectAdmin(admin.ModelAdmin):
+    list_display = ['title', 'slug']
+    prepopulated_fields = {'slug': ('title',)}
+
+class ModuleInline(admin.StackedInline):
+    model = Module
+
+@admin.register(Course)
+class CourseAdmin(admin.ModelAdmin):
+    list_display = ['title', 'subject', 'created']
+    list_filter = ['created', 'subject']
+    search_fields = ['title', 'overview']
+    prepopulated_fields = {'slug': ('title',)}
+    inlines = [ModuleInline]
+


### PR DESCRIPTION
## Description

Registered course models (Subject, Course, and Module) in the administration site.

## Changes Made

- Edited the `admin.py` file inside the courses application directory.
- Added code to register models (Subject, Course, and Module) using the `@admin.register()` decorator.
- Defined custom `SubjectAdmin` and `CourseAdmin` classes to customize the display in the administration site.
- Created an inline representation for the `Module` model within the `CourseAdmin` class.
