### PR TITLE
Implement Formsets for Course Modules

### DIFF
--- a/courses/forms.py
+++ b/courses/forms.py
@@ -1,0 +1,9 @@
+from django import forms 
+from django.forms.models import inlineformset_factory
+from .models import Course, Module 
+
+ModuleFormSet = inlineformset_factory(Course,
+                                      Module,
+                                      fields=['title', 'description'],
+                                      extra=2,
+                                      can_delete=True)

--- a/courses/templates/courses/manage/course/list.html
+++ b/courses/templates/courses/manage/course/list.html
@@ -12,6 +12,7 @@
         <p>
           <a href="{% url "course_edit" course.id %}">Edit</a>
           <a href="{% url "course_delete" course.id %}">Delete</a>
+          <a href="{% url "course_module_update" course.id %}">Edit modules</a>
         </p>
       </div>
     {% empty %}

--- a/courses/templates/courses/manage/module/formset.html
+++ b/courses/templates/courses/manage/module/formset.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+
+{% block title %}
+  Edit "{{ course.title }}"
+{% endblock %}
+
+{% block content %}
+  <h1>Edit "{{ course.title }}"</h1>
+  <div class="module">
+    <h2>Course modules</h2>
+    <form method="post">
+      {{ formset }}
+      {{ formset.management_form }}
+      {% csrf_token %}
+      <input type="submit" value="Save modules">
+    </form>
+  </div>
+{% endblock %}

--- a/courses/urls.py
+++ b/courses/urls.py
@@ -6,4 +6,5 @@ urlpatterns = [
     path('create/', views.CourseCreateView.as_view(), name='course_create'),
     path('<pk>/edit/', views.CourseUpdateView.as_view(), name='course_edit'),
     path('<pk>/delete/', views.CourseDeleteView.as_view(), name='course_delete'),
-]
+    path('<pk>/module/', views.CourseModuleUpdateView.as_view(), name='course_module_update'),
+]   

--- a/courses/views.py
+++ b/courses/views.py
@@ -4,6 +4,9 @@ from django.urls import reverse_lazy
 from django.views.generic.list import ListView
 from django.views.generic.edit import CreateView, UpdateView, DeleteView
 from django.contrib.auth.mixins import LoginRequiredMixin, PermissionRequiredMixin
+from django.shortcuts import redirect, get_object_or_404
+from django.views.generic.base import TemplateResponseMixin, View
+from .forms import ModuleFormSet
 
 # Create your views here.
 class OwnerMixin(object):
@@ -37,3 +40,25 @@ class CourseUpdateView(OwnerCourseMixin, UpdateView):
 class CourseDeleteView(OwnerCourseMixin, DeleteView):
     template_name = 'courses/manage/course/delete.html'
     permission_required = 'courses.delete_course'
+
+class CourseModuleUpdateView(TemplateResponseMixin, View):
+    template_name = 'courses/manage/module/formset.html'
+    course = None
+
+    def get_formset(self, data=None):
+        return ModuleFormSet(instance=self.course, data=data)
+    
+    def dispatch(self, request, pk):
+        self.course = get_object_or_404(Course, id=pk, owner=request.user)
+        return super().dispatch(request, pk)
+    
+    def get(self, request, *args, **kwargs):
+        formset = self.get_formset()
+        return self.render_to_response({'course': self.course,
+                                        'formset': formset})
+    
+    def post(self, request, *args, **kwargs):
+        formset = self.get_formset(data=request.POST)
+        if formset.is_valid():
+            return redirect('manage_course_list')
+        return self.render_to_response({'course': self.course, 'formset': formset})


### PR DESCRIPTION
**Changes Made:**
### Formsets Implementation:

- Created a `ModuleFormSet` formset in the `forms.py` file of the courses application.
- Used the `inlineformset_factory` function to dynamically build a model formset for `Module` objects related to a `Course` object.
- Configured formset parameters such as `fields`, `extra`, and `can_delete` for customization.

### View Handling:

- Implemented a new view, `CourseModuleUpdateView`, to handle the formset for adding, updating, and deleting modules for a specific course.
- Utilized Django mixins, including `TemplateResponseMixin` and `View`, for efficient rendering of templates and handling HTTP responses.

### URL Routing:

- Updated the `urls.py` file of the courses application to include a new URL pattern for course module updates.

### Template Modifications:

- Created a new template, `formset.html`, to render the formset for course modules.
- Integrated the formset and management form into the HTML template.
- Added  module edit link to `courses/templates/courses/manage/course/list.html`
