### PR TITLE
Implemented CourseListView and CourseDetailView for displaying available courses to public

### DIFF
--- a/courses/templates/courses/course/detail.html
+++ b/courses/templates/courses/course/detail.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+
+{% block title %}
+    {{ object.title }}
+{% endblock %}
+
+{% block content %}
+    {% with subject=object.subject %}
+        <h1>
+            {{ object.title }}
+        </h1>
+        <div class="module">
+            <h2>Overview</h2>
+            <p>
+                <a href="{% url "course_list_subject" subject.slug %}">
+                    {{ subject.title }}
+                </a>.
+                {{ object.modules.count }} modules.
+                Instructor: {{ object.owner.get_full_name }}
+            </p>
+            {{ object.overview|linebreaks }}
+        </div>
+    {% endwith %}
+{% endblock %}

--- a/courses/templates/courses/course/list.html
+++ b/courses/templates/courses/course/list.html
@@ -1,0 +1,51 @@
+{% extends "base.html" %}
+
+{% block title %}
+    {% if subject %}
+        {{ subject.title }} courses
+    {% else %}
+        All courses
+    {% endif %}
+{% endblock %}
+
+{% block content %}
+    <h1>
+        {% if subject %}
+            {{ subject.title }} courses
+        {% else %}
+            All courses
+        {% endif %}
+    </h1>
+    <div class="contents">
+        <h3>Subjects</h3>
+        <ul id="modules">
+            <li {% if not subject %}class="selected"{% endif %}>
+                <a href="{% url "course_list" %}">All</a>
+            </li>
+            {% for s in subjects %}
+                <li {% if subject == s %}class="selected"{% endif %}>
+                    <a href="{% url "course_list_subject" s.slug %}">
+                        {{ s.title }}
+                        <br><span>{{ s.total_courses }} courses</span>
+                    </a>
+                </li>
+            {% endfor %}
+        </ul>
+    </div>
+    <div class="module">
+        {% for course in courses %}
+            {% with subject=course.subject %}
+                <h3>
+                    <a href="{% url "course_detail" course.slug %}">
+                        {{ course.title }}
+                    </a>
+                </h3>
+                <p>
+                    <a href="{% url "course_list_subject" subject.slug %}">{{ subject }}</a>.
+                    {{ course.total_modules }} modules.
+                    Instructor: {{ course.owner.get_full_name }}
+                </p>
+            {% endwith %}
+        {% endfor %}
+    </div>
+{% endblock %}

--- a/courses/urls.py
+++ b/courses/urls.py
@@ -21,4 +21,6 @@ urlpatterns = [
          name='module_content_list'),
     path('module/order/', views.ModuleOrderView.as_view(), name='module_order'),
     path('content/order/', views.ContentOrderView.as_view(), name='content_order'),
+    path('subject/<slug:subject>/',views.CourseListView.as_view(),name='course_list_subject'),
+    path('<slug:slug>/', views.CourseDetailView.as_view(),  name='course_detail'),
 ]   

--- a/courses/views.py
+++ b/courses/views.py
@@ -1,5 +1,5 @@
 from django.views.generic.list import ListView
-from .models import Course, Module, Content
+from .models import Course, Module, Content,Subject
 from django.urls import reverse_lazy
 from django.views.generic.list import ListView
 from django.views.generic.edit import CreateView, UpdateView, DeleteView
@@ -130,3 +130,25 @@ class ContentOrderView(CsrfExemptMixin, JsonRequestResponseMixin, View):
         for id, order in self.request_json.items():
             Content.objects.filter(id=id, module__course__owner=request.user).update(order=order)
         return self.render_json_response({'saved': 'OK'})
+
+from django.db.models import Count
+
+class CourseListView(TemplateResponseMixin, View):
+    model = Course 
+    template_name = 'courses/course/list.html'
+
+    def get(self, request, subject=None):
+        subjects = Subject.objects.annotate(total_courses=Count('courses_created'))
+        courses = Course.objects.annotate(total_modules=Count('modules'))
+
+        if subject:
+            subject = get_object_or_404(Subject, slug=subject)
+            courses = courses.filter(subject=subject)
+
+        return self.render_to_response({'subjects': subjects, 'subject': subject, 'courses': courses})
+
+from django.views.generic.detail import DetailView
+
+class CourseDetailView(DetailView):
+    model = Course
+    template_name = 'courses/course/detail.html'

--- a/educa/urls.py
+++ b/educa/urls.py
@@ -17,10 +17,12 @@ from django.contrib import admin
 from django.urls import path
 from django.contrib.auth import views as auth_views
 from django.urls import path, include
+from courses.views import CourseListView
 
 urlpatterns = [
     path('accounts/login/', auth_views.LoginView.as_view(), name='login'),
     path('accounts/logout/', auth_views.LogoutView.as_view(), name='logout'),
     path('admin/', admin.site.urls),
     path('course/', include('courses.urls')),
+    path('', CourseListView.as_view(), name='course_list'),
 ]


### PR DESCRIPTION
## Changes Made
- Added a `CourseListView` to display all available courses, optionally filtered by subject.
- Added a `CourseDetailView` to display a single course overview.
- Updated `courses/views.py` in the courses application.
- Updated `educa/urls.py` and `courses/urls.py` to direct and handle view links within the application.
- Added templates `courses/course/detail.html` and `courses/course/list.html` to display course list and its detail.